### PR TITLE
remove enableFlake from the doc for home-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ In `$HOME/.config/nixpkgs/home.nix` add
 
   programs.direnv.enable = true;
   programs.direnv.nix-direnv.enable = true;
-  # optional for nix flakes support
-  programs.direnv.nix-direnv.enableFlakes = true;
 
   programs.bash.enable = true;
   # OR


### PR DESCRIPTION
Remove `nix-direnv.enableFlake` option from the doc as `Flake` support is now always enabled in `home-manager`.